### PR TITLE
feat(willpopup)

### DIFF
--- a/example/lib/examples/app_in_demo.dart
+++ b/example/lib/examples/app_in_demo.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:ffi';
+
 import 'package:bottom_nav_layout/bottom_nav_layout.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -7,9 +10,11 @@ import 'navigation_example.dart';
 /// This doesn't introduce something new.
 /// This is the code used in the gif demo at the top of README
 class AppInDemo extends StatelessWidget {
+
   @override
   Widget build(BuildContext context) {
     return BottomNavLayout(
+      onWillPopWithOnePageOnStack: ()=>_onWillPopWithOnePageOnStack(context),
       pages: [
         (navKey) => HomePage(navKey: navKey),
         (navKey) => DashboardPage(
@@ -39,4 +44,51 @@ class AppInDemo extends StatelessWidget {
       ),
     );
   }
+
+  Future<bool> _onWillPopWithOnePageOnStack(BuildContext context) async{
+    final response = await showAlertDialog(context);
+    return (response) ?? false;
+  }
+
+  Future<bool?> showAlertDialog(BuildContext context) async{
+
+    // set up the button
+    Widget cancelButton = TextButton(
+      child: Text("CANCEL"),
+      onPressed: () {
+        Navigator.pop(context, false);
+      },
+    );
+
+    // set up the button
+    Widget okButton = TextButton(
+      child: Text("OK"),
+      onPressed: () {
+        Navigator.pop(context, true);
+      },
+    );
+
+    // set up the AlertDialog
+    AlertDialog alert = AlertDialog(
+      title: Text("ALert!"),
+      content: Text("Sure to close app?"),
+      actions: [
+        cancelButton,
+        okButton,
+      ],
+    );
+
+    // show the dialog
+    Future<bool?> response = showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return alert;
+      },
+    );
+
+    return response;
+
+    //return response;
+  }
+
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:bottom_nav_layout/bottom_nav_layout.dart';
 import 'package:flutter/material.dart';
 
+import 'examples/app_in_demo.dart';
 import 'examples/quick_start.dart';
 import 'pages/slider_page.dart';
 
@@ -11,11 +12,11 @@ var quickStartExample = QuickStartExample();
 // var navigationExample = NavigationExample();
 // var differentBottomBarsExample = DifferentBottomBarsExample();
 // var programmaticNavigationExample = ProgrammaticNavigationExample();
-// var appInDemo = AppInDemo();
+var appInDemo = AppInDemo();
 
 void main() => runApp(MaterialApp(
       // Change the example from here
-      home: quickStartExample,
+      home: appInDemo,
     ));
 
 /// README: https://github.com/m-azyoksul/bottom_nav_layout/blob/main/README.md#parameters

--- a/lib/src/layout.dart
+++ b/lib/src/layout.dart
@@ -26,12 +26,18 @@ class BottomNavLayout extends StatefulWidget {
     this.extendBody = false,
     this.resizeToAvoidBottomInset = true,
     this.pageTransitionData,
+    this.onWillPopWithOnePageOnStack,
   })  : assert(pages.length >= 1, "At least 1 page is required"),
         assert(
             pageStack == null ||
                 pages.length > pageStack.peek() && pageStack.peek() >= 0,
             "initialPageIndex cannot exceed the page number or be negative"),
         super(key: key);
+
+  /// Custom callback when stack is with one page on stack
+  /// This way, you can show a popup before close app
+  ///
+  final WillPopCallback? onWillPopWithOnePageOnStack;
 
   /// The app's destinations.
   /// Each destination corresponds to one bottom navbar item.
@@ -152,6 +158,13 @@ class _BottomNavLayoutState extends State<BottomNavLayout> {
   /// If there is a single page in the stack, bubbles up the pop event. Exits the app if no other back button handler is configured in the app.
   Future<bool> onWillPop() async {
     // Send pop event to the inner page
+
+    //When there's only one page in stack and have custom future
+    if (widget.onWillPopWithOnePageOnStack != null && !(keys[pageStack.peek()].currentState?.canPop() ?? true)){
+      final res = await widget.onWillPopWithOnePageOnStack!.call();
+      return res;
+    }
+
     final consumedByPage =
         await keys[pageStack.peek()].currentState?.maybePop() ?? false;
 
@@ -169,10 +182,12 @@ class _BottomNavLayoutState extends State<BottomNavLayout> {
       // Set state to change the page
       setState(() {});
 
+
       // Consume pop event
       return false;
     }
 
+    print("here5");
     // Bubble up the pop event.
     return true;
   }


### PR DESCRIPTION
callback to customize action when there's one page on stack

```
bottom_nav_layout: #^3.0.9
    git:
      url: https://github.com/nowjordanhappy/bottom_nav_layout/
      ref: new-feature-willpop
```


<img width="748" alt="Screen Shot 2022-07-14 at 01 45 51" src="https://user-images.githubusercontent.com/26355419/178918681-7d8904c8-e198-4b30-bf27-e4f136671c92.png">
<img width="673" alt="Screen Shot 2022-07-14 at 01 46 02" src="https://user-images.githubusercontent.com/26355419/178918731-9ab112f2-eed4-4e07-9456-ff31c3efba7d.png">
